### PR TITLE
Add resolver to fetch the spark-test-sugar dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.idea/
 
 #Markdown editing
 .Ulysses-favorites.plist

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ organization := "com.swoop"
 
 bintrayOrganization := Some("swoop-inc")
 bintrayPackageLabels := Seq("apache", "spark", "apache-spark", "scala", "big-data", "spark-records", "dataset", "swoop")
+resolvers += "swoop-bintray" at "https://dl.bintray.com/swoop-inc/maven/"
 
 licenses +=("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
 


### PR DESCRIPTION
Thanks for building this library 😄 

I was getting this error when running `sbt test`:

```
[info] Resolving com.swoop#spark-test-sugar_2.11;1.5.0 ...
[warn] 	module not found: com.swoop#spark-test-sugar_2.11;1.5.0
[warn] ==== local: tried
[warn]   /Users/matthewpowers/.ivy2/local/com.swoop/spark-test-sugar_2.11/1.5.0/ivys/ivy.xml
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/com/swoop/spark-test-sugar_2.11/1.5.0/spark-test-sugar_2.11-1.5.0.pom
[warn] ==== local-preloaded-ivy: tried
[warn]   /Users/matthewpowers/.sbt/preloaded/com.swoop/spark-test-sugar_2.11/1.5.0/ivys/ivy.xml
[warn] ==== local-preloaded: tried
[warn]   file:////Users/matthewpowers/.sbt/preloaded/com/swoop/spark-test-sugar_2.11/1.5.0/spark-test-sugar_2.11-1.5.0.pom
[warn] ==== tpolecat: tried
[warn]   http://dl.bintray.com/tpolecat/maven/com/swoop/spark-test-sugar_2.11/1.5.0/spark-test-sugar_2.11-1.5.0.pom
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: com.swoop#spark-test-sugar_2.11;1.5.0: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
```

It was looking in `http://dl.bintray.com/tpolecat/maven/com/swoop/spark-test-sugar_2.11` for spark-test-sugar instead of in `https://dl.bintray.com/swoop-inc/maven/`.  Adding the resolver in the `build.sbt` file fixes this build on my machine.  Quite the strange error message!